### PR TITLE
Set downView to private set to give access in unit tests

### DIFF
--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,4 +1,4 @@
-github "SVProgressHUD/SVProgressHUD" "2.2.2"
+github "SVProgressHUD/SVProgressHUD" "2.2.5"
 github "ashleymills/Reachability.swift" "v3.0"
-github "iwasrobbed/Down" "v0.4.2"
-github "malcommac/SwiftRichString" "1.0.1"
+github "iwasrobbed/Down" "v0.5.0"
+github "malcommac/SwiftRichString" "1.1.0"

--- a/swift-evolution.xcodeproj/project.pbxproj
+++ b/swift-evolution.xcodeproj/project.pbxproj
@@ -79,6 +79,7 @@
 		91E150281E6D15B100025B77 /* DGCollectionViewLeftAlignFlowLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91E150271E6D15B100025B77 /* DGCollectionViewLeftAlignFlowLayout.swift */; };
 		91E1502A1E6D250E00025B77 /* Array.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91E150291E6D250E00025B77 /* Array.swift */; };
 		91F05E641F034F78002738F4 /* Reachability.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 91F05E631F034F78002738F4 /* Reachability.framework */; };
+		A2B7B61C2046F6F20022FA74 /* ProposalDetailViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2B7B61B2046F6F20022FA74 /* ProposalDetailViewControllerTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -213,6 +214,7 @@
 		91E150291E6D250E00025B77 /* Array.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Array.swift; sourceTree = "<group>"; };
 		91F05E611F034992002738F4 /* SystemConfiguration.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SystemConfiguration.framework; path = System/Library/Frameworks/SystemConfiguration.framework; sourceTree = SDKROOT; };
 		91F05E631F034F78002738F4 /* Reachability.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Reachability.framework; path = Carthage/Build/iOS/Reachability.framework; sourceTree = "<group>"; };
+		A2B7B61B2046F6F20022FA74 /* ProposalDetailViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProposalDetailViewControllerTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -315,6 +317,7 @@
 		915265391E67659A00C2AFDA /* swift-evolutionTests */ = {
 			isa = PBXGroup;
 			children = (
+				A2B7B6192046F6D20022FA74 /* controllers */,
 				9152653C1E67659A00C2AFDA /* Info.plist */,
 				9152653A1E67659A00C2AFDA /* swift_evolutionTests.swift */,
 			);
@@ -629,6 +632,14 @@
 			path = DGCollectionViewLeftAlignFlowLayout;
 			sourceTree = "<group>";
 		};
+		A2B7B6192046F6D20022FA74 /* controllers */ = {
+			isa = PBXGroup;
+			children = (
+				A2B7B61B2046F6F20022FA74 /* ProposalDetailViewControllerTests.swift */,
+			);
+			path = controllers;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
@@ -917,6 +928,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				9152653B1E67659A00C2AFDA /* swift_evolutionTests.swift in Sources */,
+				A2B7B61C2046F6F20022FA74 /* ProposalDetailViewControllerTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/swift-evolution/resources/storyboards/Base.lproj/Main.storyboard
+++ b/swift-evolution/resources/storyboards/Base.lproj/Main.storyboard
@@ -299,11 +299,11 @@ Swift and the Swift logo are trademarks of Apple Inc. For more information about
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="UrU-21-DUf">
-                                <rect key="frame" x="0.0" y="0.0" width="375" height="603"/>
+                                <rect key="frame" x="0.0" y="64" width="375" height="603"/>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                             </view>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="No Selected Proposal" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="PVc-xW-YFk">
-                                <rect key="frame" x="140.5" y="263" width="94" height="77"/>
+                                <rect key="frame" x="140.5" y="295" width="94" height="77"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="77" id="Aoo-b9-Z6D"/>
                                 </constraints>
@@ -563,7 +563,7 @@ Swift and the Swift logo are trademarks of Apple Inc. For more information about
     </resources>
     <inferredMetricsTieBreakers>
         <segue reference="rf2-rv-6M0"/>
-        <segue reference="3pf-Ye-P5i"/>
+        <segue reference="XKc-wh-heR"/>
         <segue reference="sHa-dI-MgD"/>
     </inferredMetricsTieBreakers>
 </document>

--- a/swift-evolution/resources/storyboards/Base.lproj/Main.storyboard
+++ b/swift-evolution/resources/storyboards/Base.lproj/Main.storyboard
@@ -299,11 +299,11 @@ Swift and the Swift logo are trademarks of Apple Inc. For more information about
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="UrU-21-DUf">
-                                <rect key="frame" x="0.0" y="64" width="375" height="603"/>
+                                <rect key="frame" x="0.0" y="0.0" width="375" height="603"/>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                             </view>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="No Selected Proposal" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="PVc-xW-YFk">
-                                <rect key="frame" x="140.5" y="295" width="94" height="77"/>
+                                <rect key="frame" x="140.5" y="263" width="94" height="77"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="77" id="Aoo-b9-Z6D"/>
                                 </constraints>
@@ -563,7 +563,7 @@ Swift and the Swift logo are trademarks of Apple Inc. For more information about
     </resources>
     <inferredMetricsTieBreakers>
         <segue reference="rf2-rv-6M0"/>
-        <segue reference="XKc-wh-heR"/>
+        <segue reference="3pf-Ye-P5i"/>
         <segue reference="sHa-dI-MgD"/>
     </inferredMetricsTieBreakers>
 </document>

--- a/swift-evolution/sourcecode/controllers/proposals/detail/ProposalDetailViewController.swift
+++ b/swift-evolution/sourcecode/controllers/proposals/detail/ProposalDetailViewController.swift
@@ -12,7 +12,7 @@ class ProposalDetailViewController: BaseViewController {
 
     // MARK: - Private properties
     private var proposalMarkdown: String?
-    private var downView: DownView?
+    public private(set) var downView: DownView?
     fileprivate weak var appDelegate: AppDelegate?
     private var shareButton: UIBarButtonItem?
 

--- a/swift-evolution/sourcecode/controllers/proposals/detail/ProposalDetailViewController.swift
+++ b/swift-evolution/sourcecode/controllers/proposals/detail/ProposalDetailViewController.swift
@@ -12,7 +12,7 @@ class ProposalDetailViewController: BaseViewController {
 
     // MARK: - Private properties
     private var proposalMarkdown: String?
-    public private(set) var downView: DownView?
+    internal private(set) var downView: DownView?
     fileprivate weak var appDelegate: AppDelegate?
     private var shareButton: UIBarButtonItem?
 

--- a/swift-evolutionTests/controllers/ProposalDetailViewControllerTests.swift
+++ b/swift-evolutionTests/controllers/ProposalDetailViewControllerTests.swift
@@ -64,13 +64,4 @@ class ProposalDetailViewControllerTests: XCTestCase {
     func testInstanceofDownView() {
          XCTAssertNotNil(self.proposalDetailViewController.downView)
     }
-    
-//    func testWKNavigationDelegate () {
-//        self.proposalDetailViewController.downView?.navigationDelegate = mockWebView
-//        self.proposalDetailViewController.downView?.reload()
-//        self.proposalDetailViewController.downView?.load(mockRequest)
-//        try? self.proposalDetailViewController.downView?.update(markdownString: "**markdown**", didLoadSuccessfully: {
-//        })
-//        RunLoop.main.run(until: Date(timeIntervalSinceNow: 0.5))
-//    }
 }

--- a/swift-evolutionTests/controllers/ProposalDetailViewControllerTests.swift
+++ b/swift-evolutionTests/controllers/ProposalDetailViewControllerTests.swift
@@ -1,0 +1,76 @@
+import XCTest
+import WebKit
+import Down
+@testable import swift_evolution
+
+class MockWKNavigation: NSObject {
+    
+    var delegateCalled: Bool = false
+    
+}
+
+extension MockWKNavigation: WKNavigationDelegate {
+    
+    func webView(_ webView: WKWebView, decidePolicyFor navigationAction: WKNavigationAction, decisionHandler: @escaping (WKNavigationActionPolicy) -> Void) {
+        self.delegateCalled = true
+    }
+    
+}
+
+class ProposalDetailViewControllerTests: XCTestCase {
+    
+    var proposalDetailViewController: ProposalDetailViewController!
+    var mockWebView: MockWKNavigation!
+    var mockProposal: Proposal = Proposal(id: 0, link: "https://github.com/swift")
+    var mockRequest: URLRequest = URLRequest(url: URL(string: "https://github.com/swift")!)
+    
+    override func setUp() {
+        super.setUp()
+        let storyboard = UIStoryboard(name: "Main", bundle: nil)
+        self.proposalDetailViewController = storyboard.instantiateViewController(withIdentifier: "ProposalDetailStoryboardID") as? ProposalDetailViewController
+        _ = proposalDetailViewController.view
+        self.mockWebView = MockWKNavigation()
+    }
+    
+    override func tearDown() {
+        super.tearDown()
+    }
+    
+    func testCanInstantiateProposalDetailViewController() {
+        XCTAssertNotNil(proposalDetailViewController)
+    }
+    
+    func testProposalDetailViewControllerViewDidLoad() {
+        self.proposalDetailViewController.viewDidLoad()
+        XCTAssertNotNil(proposalDetailViewController)
+    }
+    
+    func testProposalDetailViewControllerViewWillAppear() {
+        self.proposalDetailViewController.viewWillAppear(true)
+        self.proposalDetailViewController.viewWillAppear(false)
+        XCTAssertNotNil(proposalDetailViewController)
+    }
+    
+    func testProposalDetailViewControllerDidReceiveMemoryWarning() {
+        self.proposalDetailViewController.didReceiveMemoryWarning()
+        XCTAssertNotNil(proposalDetailViewController)
+    }
+    
+    func testConformsToWKNavigationDelegate () {
+        XCTAssert(self.proposalDetailViewController.conforms(to: WKNavigationDelegate.self))
+        XCTAssertTrue(proposalDetailViewController.responds(to: #selector(proposalDetailViewController.webView(_:decidePolicyFor:decisionHandler:))))
+    }
+    
+    func testInstanceofDownView() {
+         XCTAssertNotNil(self.proposalDetailViewController.downView)
+    }
+    
+//    func testWKNavigationDelegate () {
+//        self.proposalDetailViewController.downView?.navigationDelegate = mockWebView
+//        self.proposalDetailViewController.downView?.reload()
+//        self.proposalDetailViewController.downView?.load(mockRequest)
+//        try? self.proposalDetailViewController.downView?.update(markdownString: "**markdown**", didLoadSuccessfully: {
+//        })
+//        RunLoop.main.run(until: Date(timeIntervalSinceNow: 0.5))
+//    }
+}


### PR DESCRIPTION
## Changes in this pull request

Changed `private var downView: DownView?` to `public private(set) var downView: DownView?` to access it in the unit tests. 

A small start in unit tests can be found in the `ProposalDetailViewControllerTests.swift`

(ps: thanks a lot @diogot for all patience in the review)

(Not totally fixed, but started)
Issue fixed: #104 

### Checklist

- [x] Project builds and runs as expected.
- [x] No new linting violations have been introduced.
- [x] No new bugs have been introduced.
- [x] I have reviewed the [contributing guide](https://github.com/evolution-app/ios/blob/development/.github/CONTRIBUTING.md)
- [ ] I'm attaching to this PR some screenshots (if applicable)