### PR TITLE
Fix proposals decoding issue

### DIFF
--- a/swift-evolution/sourcecode/models/Proposal.swift
+++ b/swift-evolution/sourcecode/models/Proposal.swift
@@ -1,5 +1,9 @@
 import Foundation
 
+struct ProposalResponse: Decodable {
+    let proposals: [Proposal]
+}
+
 struct Proposal: Decodable {
     let id: Int
     let title: String

--- a/swift-evolution/sourcecode/models/State.swift
+++ b/swift-evolution/sourcecode/models/State.swift
@@ -49,29 +49,29 @@ extension StatusState: RawRepresentable {
     
     public init?(rawValue: RawValue) {
         switch rawValue.identifier {
-        case ".awaitingReview":
+        case "awaitingReview":
             self = .awaitingReview
-        case ".scheduledForReview":
+        case "scheduledForReview":
             self = .scheduledForReview
-        case ".activeReview":
+        case "activeReview":
             self = .activeReview
-        case ".returnedForRevision":
+        case "returnedForRevision":
             self = .returnedForRevision
-        case ".withdrawn":
+        case "withdrawn":
             self = .withdrawn
-        case ".deferred":
+        case "deferred":
             self = .deferred
-        case ".accepted":
+        case "accepted":
             self = .accepted
-        case ".acceptedWithRevisions":
+        case "acceptedWithRevisions":
             self = .acceptedWithRevisions
-        case ".rejected":
+        case "rejected":
             self = .rejected
-        case ".implemented":
+        case "implemented":
             self = .implemented
-        case ".previewing":
+        case "previewing":
             self = .previewing
-        case ".error":
+        case "error":
             self = .error
             
         default:

--- a/swift-evolution/sourcecode/services/Service+Evolution.swift
+++ b/swift-evolution/sourcecode/services/Service+Evolution.swift
@@ -10,7 +10,9 @@ struct EvolutionService {
         let request = RequestSettings(url)
 
         Service.dispatch(request) { result in
-            let newResult = result.flatMap { try JSONDecoder().decode([Proposal].self, from: $0) }
+            let newResult = result
+                .flatMap { try JSONDecoder().decode(ProposalResponse.self, from: $0) }
+                .flatMap { $0.proposals }
             completion(newResult)
         }
     }


### PR DESCRIPTION
## Changes in this pull request

Issue fixed: 
**1st:** Proposals are not being presented because the `/proposals` response has changed

Explanation.
Earlier, the `/proposals` endpoint returned an array of `proposals`, but now it returns a dictionary with additional details alongside the `proposals`.
<img width="632" alt="Screenshot 2024-09-03 at 11 59 05" src="https://github.com/user-attachments/assets/45d696b4-16eb-426b-8792-48d816e7bfa6">


**2nd:** Proposals are not being presented because the `State.rawValue` from the `/proposals` response probably has changed

Explanation.
The `/proposals` endpoint contains a `status` field within the `state` field of type `String`. 
```
"status": {
   "state": "implemented"
}
```
I assume that the `state` response changed, so the app couldn't decode it and returned a `ServiceError.invalidResponse ` error.
<img width="586" alt="Screenshot 2024-09-03 at 12 07 54" src="https://github.com/user-attachments/assets/a0668cab-b726-4fd3-a5ee-ace222e3b1df">

### Checklist

- [x] Project builds and runs as expected.
- [x] No new linting violations have been introduced.
- [x] No new bugs have been introduced.
- [x] I have reviewed the [contributing guide](https://github.com/evolution-app/ios/blob/development/.github/CONTRIBUTING.md)
- [x] I'm attaching to this PR some screenshots (if applicable)